### PR TITLE
Add systed file templating

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Priority: optional
 Build-Depends: curl,
                debhelper-compat (= 13),
                dh-sequence-installsysusers,
+               fypp:native,
                help2man,
                libvips-dev (>= 8.17.2),
                nodejs (>= 24) | npm,

--- a/debian/immich-machine-learning.service.fypp
+++ b/debian/immich-machine-learning.service.fypp
@@ -1,47 +1,31 @@
 # Please consider only editing this file through systemd drop-in files
-# (e.g. `systemctl edit immich-server`). This will enable you to get updates
+# (e.g. `systemctl edit immich-machine-learning`). This will enable you to get updates
 # to this file automatically, without your overrides being lost.
 
 # Refer to the manpage `systemd.unit` for detailed documentation on each option.
 [Unit]
-Description=immich main server
+Description=immich machine-learning server
 Documentation=https://github.com/immich-app/immich
 # The service requires network interfaces to be configured.
 After=network.target
 # If you want to expose the server to the network directly, you may find the following useful:
 #After=network-online.target
 
-# If immich-machine-learning, postgresql and/or redis are running on this system they should be specified as dependencies,
-# such that immich-server is only started after (`After=`) those have successfully (`Requires=`) started.
-#After=immich-machine-learning.service postgresql.service redis.service
-#Requires=immich-machine-learning.service postgresql.service redis.service
-
-# If running immich behind a reverse proxy - running on this system - consider ordering it before also:
-#Before=theproxy.service
-
 # Refer to the manpages `systemd.service` and `systemd.exec` for detailed documentation on each option.
 [Service]
 ## Service execution environment
 # Service configuration file.
-EnvironmentFile=-%E/default/immich-server
+EnvironmentFile=-%E/default/immich-machine-learning
 # build info
-EnvironmentFile=/usr/share/doc/immich-server/build.env
+EnvironmentFile=/usr/share/doc/immich-machine-learning/build.env
 # Service execution.
 Type=exec
 ExecStart=/bin/sh -c ' \
   set -a; \
-  . /etc/immich/server.env; \
+  . /etc/immich/machine-learning.env; \
   set +a; \
-  if [ -z "$UV_THREADPOOL_SIZE" ]; then \
-    CPU_CORES=$(/usr/lib/immich/server/bin/get-cpus.sh); \
-    if [ "$CPU_CORES" -gt 4 ]; then \
-      UV_THREADPOOL_SIZE=$CPU_CORES; \
-    fi; \
-  fi; \
-  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jellyfin-ffmpeg/lib \
-  PATH=/usr/lib/jellyfin-ffmpeg:$PATH \
-  exec node dist/main "$@"'
-WorkingDirectory=/usr/lib/immich/server
+  exec /usr/lib/immich/machine-learning/bin/uv run --extra $DEVICE -m immich_ml'
+WorkingDirectory=/usr/lib/immich/machine-learning
 # Restart on failure
 Restart=on-failure
 RestartSec=5s
@@ -49,17 +33,19 @@ RestartSec=5s
 ## Permissions and directories
 User=immich
 Group=immich
+#:if SYSTEMD_MAJOR >= 257
 # Read-only configuration directory (read-only mount, permissions managed by tmpfiles, warns if mode differs).
 ConfigurationDirectory=immich::ro
+#:else
+# Configuration directory (permissions managed by tmpfiles, warns if mode differs).
+ConfigurationDirectory=immich
+#:endif
 ConfigurationDirectoryMode=0500
 # Writable directories (read-write for the service, read-only for the group, reapplies permissions recursively if different).
-StateDirectory=immich immich/data immich/plugins
-StateDirectoryMode=0750
+CacheDirectory=immich
+CacheDirectoryMode=0750
 # File creation mask (matching modes above).
 UMask=0027
-# External directories (grant write access to a folder outside of service-managed directories above).
-#ReadWritePaths=/path/to/your/folder
-# BindPaths= is an alternative, but its interactions with other directives here require careful consideration.
 
 ## Connection and process limits
 LimitNOFILE=1048576
@@ -72,12 +58,12 @@ LimitNPROC=512
 #MemoryMax=4G
 
 ## Sandboxing and isolation
-# An overview is available using `systemd-analyze security immich-server`.
+# An overview is available using `systemd-analyze security immich-machine-learning`.
 
 ## Capabilities
 AmbientCapabilities=
 CapabilityBoundingSet=
-# Uncomment these to allow immich-server to bind to ports in the range 0-1024.
+# Uncomment these to allow immich-machine-learning to bind to ports in the range 0-1024.
 #AmbientCapabilities=CAP_NET_BIND_SERVICE
 #CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
@@ -90,13 +76,19 @@ SecureBits=noroot noroot-locked
 ProtectSystem=strict
 ProtectHome=true
 ProtectProc=noaccess
-# ProcSubset=pid # not possible right now, get-cpus.sh wants to read /proc/cpuinfo
+ProcSubset=pid
 
 # Namespace isolation
+#:if SYSTEMD_MAJOR >= 257
 PrivateTmp=disconnected
+#:else
+PrivateTmp=true
+#:endif
 PrivateIPC=true
+#:if SYSTEMD_MAJOR >= 258
 PrivateBPF=true
-# Allow hardware-accelerated transcoding.
+#:endif
+# Allow hardware-accelerated ML inference.
 PrivateDevices=true
 DevicePolicy=closed
 # Intel/AMD (VAAPI, QuickSync)
@@ -117,12 +109,18 @@ ProtectClock=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectKernelLogs=true
+#:if SYSTEMD_MAJOR >= 257
 ProtectControlGroups=strict
+#:else
+ProtectControlGroups=true
+#:endif
 
 # Execution restrictions
-# Allow for V8 JIT compiler.
+# Allow for Python JIT and NumPy optimizations.
 MemoryDenyWriteExecute=false
+#:if SYSTEMD_MAJOR >= 255
 SetLoginEnvironment=false
+#:endif
 
 # System call and network filtering
 SystemCallFilter=@system-service

--- a/debian/immich-server.service.fypp
+++ b/debian/immich-server.service.fypp
@@ -1,31 +1,47 @@
 # Please consider only editing this file through systemd drop-in files
-# (e.g. `systemctl edit immich-machine-learning`). This will enable you to get updates
+# (e.g. `systemctl edit immich-server`). This will enable you to get updates
 # to this file automatically, without your overrides being lost.
 
 # Refer to the manpage `systemd.unit` for detailed documentation on each option.
 [Unit]
-Description=immich machine-learning server
+Description=immich main server
 Documentation=https://github.com/immich-app/immich
 # The service requires network interfaces to be configured.
 After=network.target
 # If you want to expose the server to the network directly, you may find the following useful:
 #After=network-online.target
 
+# If immich-machine-learning, postgresql and/or redis are running on this system they should be specified as dependencies,
+# such that immich-server is only started after (`After=`) those have successfully (`Requires=`) started.
+#After=immich-machine-learning.service postgresql.service redis.service
+#Requires=immich-machine-learning.service postgresql.service redis.service
+
+# If running immich behind a reverse proxy - running on this system - consider ordering it before also:
+#Before=theproxy.service
+
 # Refer to the manpages `systemd.service` and `systemd.exec` for detailed documentation on each option.
 [Service]
 ## Service execution environment
 # Service configuration file.
-EnvironmentFile=-%E/default/immich-machine-learning
+EnvironmentFile=-%E/default/immich-server
 # build info
-EnvironmentFile=/usr/share/doc/immich-machine-learning/build.env
+EnvironmentFile=/usr/share/doc/immich-server/build.env
 # Service execution.
 Type=exec
 ExecStart=/bin/sh -c ' \
   set -a; \
-  . /etc/immich/machine-learning.env; \
+  . /etc/immich/server.env; \
   set +a; \
-  exec /usr/lib/immich/machine-learning/bin/uv run --extra $DEVICE -m immich_ml'
-WorkingDirectory=/usr/lib/immich/machine-learning
+  if [ -z "$UV_THREADPOOL_SIZE" ]; then \
+    CPU_CORES=$(/usr/lib/immich/server/bin/get-cpus.sh); \
+    if [ "$CPU_CORES" -gt 4 ]; then \
+      UV_THREADPOOL_SIZE=$CPU_CORES; \
+    fi; \
+  fi; \
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jellyfin-ffmpeg/lib \
+  PATH=/usr/lib/jellyfin-ffmpeg:$PATH \
+  exec node dist/main "$@"'
+WorkingDirectory=/usr/lib/immich/server
 # Restart on failure
 Restart=on-failure
 RestartSec=5s
@@ -33,14 +49,22 @@ RestartSec=5s
 ## Permissions and directories
 User=immich
 Group=immich
+#:if SYSTEMD_MAJOR >= 257
 # Read-only configuration directory (read-only mount, permissions managed by tmpfiles, warns if mode differs).
 ConfigurationDirectory=immich::ro
+#:else
+# Configuration directory (permissions managed by tmpfiles, warns if mode differs).
+ConfigurationDirectory=immich
+#:endif
 ConfigurationDirectoryMode=0500
 # Writable directories (read-write for the service, read-only for the group, reapplies permissions recursively if different).
-CacheDirectory=immich
-CacheDirectoryMode=0750
+StateDirectory=immich immich/data immich/plugins
+StateDirectoryMode=0750
 # File creation mask (matching modes above).
 UMask=0027
+# External directories (grant write access to a folder outside of service-managed directories above).
+#ReadWritePaths=/path/to/your/folder
+# BindPaths= is an alternative, but its interactions with other directives here require careful consideration.
 
 ## Connection and process limits
 LimitNOFILE=1048576
@@ -53,12 +77,12 @@ LimitNPROC=512
 #MemoryMax=4G
 
 ## Sandboxing and isolation
-# An overview is available using `systemd-analyze security immich-machine-learning`.
+# An overview is available using `systemd-analyze security immich-server`.
 
 ## Capabilities
 AmbientCapabilities=
 CapabilityBoundingSet=
-# Uncomment these to allow immich-machine-learning to bind to ports in the range 0-1024.
+# Uncomment these to allow immich-server to bind to ports in the range 0-1024.
 #AmbientCapabilities=CAP_NET_BIND_SERVICE
 #CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
@@ -71,13 +95,19 @@ SecureBits=noroot noroot-locked
 ProtectSystem=strict
 ProtectHome=true
 ProtectProc=noaccess
-ProcSubset=pid
+# ProcSubset=pid # not possible right now, get-cpus.sh wants to read /proc/cpuinfo
 
 # Namespace isolation
+#:if SYSTEMD_MAJOR >= 257
 PrivateTmp=disconnected
+#:else
+PrivateTmp=true
+#:endif
 PrivateIPC=true
+#:if SYSTEMD_MAJOR >= 258
 PrivateBPF=true
-# Allow hardware-accelerated ML inference.
+#:endif
+# Allow hardware-accelerated transcoding.
 PrivateDevices=true
 DevicePolicy=closed
 # Intel/AMD (VAAPI, QuickSync)
@@ -98,12 +128,18 @@ ProtectClock=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectKernelLogs=true
+#:if SYSTEMD_MAJOR >= 257
 ProtectControlGroups=strict
+#:else
+ProtectControlGroups=true
+#:endif
 
 # Execution restrictions
-# Allow for Python JIT and NumPy optimizations.
+# Allow for V8 JIT compiler.
 MemoryDenyWriteExecute=false
+#:if SYSTEMD_MAJOR >= 255
 SetLoginEnvironment=false
+#:endif
 
 # System call and network filtering
 SystemCallFilter=@system-service

--- a/debian/rules
+++ b/debian/rules
@@ -46,6 +46,14 @@ UV_VERSION = 0.9.30
 UV_SHA256_x86_64 = 8b3762374972daa7a74bbc6896cc73229ca69a07403dd9f9ea3805a51ffd7582
 UV_SHA256_aarch64 = 6aadf3c71600d594e16dabf382cc15282ead4c5ca768599b6bcb43c5004d9aa8
 
+# Detect systemd major version for service file templating.
+# On bookworm systemd.pc ships with the systemd package; on newer distros it moved to systemd-dev.
+# TODO: once bookworm is phased out, add systemd-dev to Build-Depends and drop the dpkg-query fallback.
+SYSTEMD_MAJOR := $(shell pkgconf --modversion systemd 2>/dev/null)
+ifeq ($(SYSTEMD_MAJOR),)
+SYSTEMD_MAJOR := $(shell dpkg-query -W -f='$${Version}' libsystemd0 2>/dev/null | cut -d. -f1)
+endif
+
 # steps mostly imitate official docker images, so changes there may need to be reflected here
 # - https://github.com/immich-app/base-images/blob/main/server/Dockerfile
 # - https://github.com/immich-app/immich/blob/main/server/Dockerfile
@@ -152,6 +160,10 @@ override_dh_prep:
 	dh_prep -X $(TMPDEB)
 
 # Don't automatically start immich-server on installation it requires configuration first but restart on upgrade if it was running
+execute_before_dh_installsystemd:
+	fypp -DSYSTEMD_MAJOR=$(SYSTEMD_MAJOR) debian/immich-server.service.fypp debian/immich-server.service
+	fypp -DSYSTEMD_MAJOR=$(SYSTEMD_MAJOR) debian/immich-machine-learning.service.fypp debian/immich-machine-learning.service
+
 override_dh_installsystemd:
 	dh_installsystemd -pimmich-server --no-start --restart-after-upgrade
 	dh_installsystemd -pimmich-machine-learning


### PR DESCRIPTION
It was bound to happen one day that a directive is not understood in older systemd versions and its interpretations not yielding the desired effect. By introducing a small template we can also target warnings and be more specific for each supported version.